### PR TITLE
Remove `-k` AKA `--insecure` from cURL command

### DIFF
--- a/create-image.sh
+++ b/create-image.sh
@@ -85,7 +85,7 @@ verify_tails () {
 }
 
 download_tails () {
-  curl -k -o data/tails-tmp.iso $TAILS_ISO_URL
+  curl -o data/tails-tmp.iso $TAILS_ISO_URL
   mv data/tails-tmp.iso data/tails.iso
 }
 


### PR DESCRIPTION
`-k` "explicitly allows curl to perform "insecure" SSL connections and transfers". This is unwise for this application, but furthermore, is superfluous in this case because the iso is not downloaded using a connection secured by SSL
